### PR TITLE
fix(test): resolve CI test failures for SubscriptionService

### DIFF
--- a/src/DodoPayments.Client.Tests/Models/Subscriptions/SubscriptionPreviewChangePlanResponseTest.cs
+++ b/src/DodoPayments.Client.Tests/Models/Subscriptions/SubscriptionPreviewChangePlanResponseTest.cs
@@ -1400,7 +1400,7 @@ public class LineItemSubscriptionTest : TestBase
         string expectedDescription = "description";
         string expectedName = "name";
         int expectedTax = 0;
-        float expectedTaxRate = 0;
+        double expectedTaxRate = 0;
 
         Assert.Equal(expectedID, model.ID);
         Assert.Equal(expectedCurrency, model.Currency);
@@ -1482,7 +1482,7 @@ public class LineItemSubscriptionTest : TestBase
         string expectedDescription = "description";
         string expectedName = "name";
         int expectedTax = 0;
-        float expectedTaxRate = 0;
+        double expectedTaxRate = 0;
 
         Assert.Equal(expectedID, deserialized.ID);
         Assert.Equal(expectedCurrency, deserialized.Currency);
@@ -1725,7 +1725,7 @@ public class AddonTest : TestBase
         int expectedQuantity = 0;
         ApiEnum<string, TaxCategory> expectedTaxCategory = TaxCategory.DigitalProducts;
         bool expectedTaxInclusive = true;
-        float expectedTaxRate = 0;
+        double expectedTaxRate = 0;
         ApiEnum<string, AddonType> expectedType = AddonType.Addon;
         int expectedUnitPrice = 0;
         string expectedDescription = "description";
@@ -1800,7 +1800,7 @@ public class AddonTest : TestBase
         int expectedQuantity = 0;
         ApiEnum<string, TaxCategory> expectedTaxCategory = TaxCategory.DigitalProducts;
         bool expectedTaxInclusive = true;
-        float expectedTaxRate = 0;
+        double expectedTaxRate = 0;
         ApiEnum<string, AddonType> expectedType = AddonType.Addon;
         int expectedUnitPrice = 0;
         string expectedDescription = "description";
@@ -2045,7 +2045,7 @@ public class MeterTest : TestBase
         string expectedPricePerUnit = "price_per_unit";
         int expectedSubtotal = 0;
         bool expectedTaxInclusive = true;
-        float expectedTaxRate = 0;
+        double expectedTaxRate = 0;
         ApiEnum<string, MeterType> expectedType = MeterType.Meter;
         string expectedUnitsConsumed = "units_consumed";
         string expectedDescription = "description";
@@ -2124,7 +2124,7 @@ public class MeterTest : TestBase
         string expectedPricePerUnit = "price_per_unit";
         int expectedSubtotal = 0;
         bool expectedTaxInclusive = true;
-        float expectedTaxRate = 0;
+        double expectedTaxRate = 0;
         ApiEnum<string, MeterType> expectedType = MeterType.Meter;
         string expectedUnitsConsumed = "units_consumed";
         string expectedDescription = "description";

--- a/src/DodoPayments.Client/Models/Subscriptions/SubscriptionPreviewChangePlanResponse.cs
+++ b/src/DodoPayments.Client/Models/Subscriptions/SubscriptionPreviewChangePlanResponse.cs
@@ -283,11 +283,11 @@ public record class LineItem : ModelBase
         }
     }
 
-    public float? TaxRate
+    public double? TaxRate
     {
         get
         {
-            return Match<float?>(
+            return Match<double?>(
                 subscription: (x) => x.TaxRate,
                 addon: (x) => x.TaxRate,
                 meter: (x) => x.TaxRate
@@ -700,12 +700,12 @@ public sealed record class LineItemSubscription : JsonModel
         init { this._rawData.Set("tax", value); }
     }
 
-    public float? TaxRate
+    public double? TaxRate
     {
         get
         {
             this._rawData.Freeze();
-            return this._rawData.GetNullableStruct<float>("tax_rate");
+            return this._rawData.GetNullableStruct<double>("tax_rate");
         }
         init { this._rawData.Set("tax_rate", value); }
     }
@@ -883,12 +883,12 @@ public sealed record class Addon : JsonModel
         init { this._rawData.Set("tax_inclusive", value); }
     }
 
-    public required float TaxRate
+    public required double TaxRate
     {
         get
         {
             this._rawData.Freeze();
-            return this._rawData.GetNotNullStruct<float>("tax_rate");
+            return this._rawData.GetNotNullStruct<double>("tax_rate");
         }
         init { this._rawData.Set("tax_rate", value); }
     }
@@ -1109,12 +1109,12 @@ public sealed record class Meter : JsonModel
         init { this._rawData.Set("tax_inclusive", value); }
     }
 
-    public required float TaxRate
+    public required double TaxRate
     {
         get
         {
             this._rawData.Freeze();
-            return this._rawData.GetNotNullStruct<float>("tax_rate");
+            return this._rawData.GetNotNullStruct<double>("tax_rate");
         }
         init { this._rawData.Set("tax_rate", value); }
     }

--- a/src/DodoPayments.Client/Models/Subscriptions/SubscriptionUpdatePaymentMethodParams.cs
+++ b/src/DodoPayments.Client/Models/Subscriptions/SubscriptionUpdatePaymentMethodParams.cs
@@ -133,8 +133,14 @@ public record class SubscriptionUpdatePaymentMethodParams : ParamsBase
 
     internal override HttpContent? BodyContent()
     {
+        // The "body" key wraps the union type; the API expects the union content directly.
+        var rawBody = this.RawBodyData;
+        object content =
+            rawBody.Count == 1 && rawBody.TryGetValue("body", out var bodyElement)
+                ? (object)bodyElement
+                : rawBody;
         return new StringContent(
-            JsonSerializer.Serialize(this.RawBodyData, ModelBase.SerializerOptions),
+            JsonSerializer.Serialize(content, ModelBase.SerializerOptions),
             Encoding.UTF8,
             "application/json"
         );


### PR DESCRIPTION
## Summary

Fixes two failing CI tests in `SubscriptionServiceTest` that were causing CI failures on both `main` and `next` branches.

### Bug 1: `UpdatePaymentMethod_Works` — HTTP 422 (both net472 & net8.0)

**Root cause:** `SubscriptionUpdatePaymentMethodParams.BodyContent()` serialized the full `RawBodyData` dictionary, which wraps the union-typed request body under a `"body"` key. This sent `{"body":{"type":"new",...}}` to the mock server, but the OpenAPI spec (`UpdatePaymentMethodReq`) defines the request body as a direct `oneOf` — expecting `{"type":"new",...}` without wrapping.

**Fix:** Updated `BodyContent()` to detect when `RawBodyData` contains only a single `"body"` key (the union wrapper) and serialize just the union content directly.

### Bug 2: `PreviewChangePlan_Works` — LineItem deserialization failure (net472 only)

**Root cause:** The Prism mock server generates boundary values for `format: float` fields (e.g., `tax_rate: -3.402823669209385e+38`). This value exceeds `System.Single` (float) range on .NET Framework 4.7.2, causing `JsonSerializer.Deserialize<float?>()` to throw. Since `LineItemConverter.Read` tries all three variants (Subscription/Addon/Meter) and each fails on `TaxRate` deserialization, the converter falls through to a null-value `LineItem`, which then fails `Validate()`.

**Fix:** Changed `TaxRate` from `float`/`float?` to `double`/`double?` across `LineItem`, `LineItemSubscription`, `Addon`, and `Meter` types. This matches JSON's inherent double-precision number representation and avoids cross-framework float parsing differences.

### Verification

- Build succeeds on both `netstandard2.0` and `net8.0` targets
- All 4240 tests pass locally on net8.0 (0 failures, 2 pre-existing skips)